### PR TITLE
feat/#70 css 대시보드, 사이드바 전체 수정

### DIFF
--- a/potfill/.classpath
+++ b/potfill/.classpath
@@ -37,15 +37,18 @@
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/potfill/src/main/webapp/WEB-INF/assets/css/admin/admin-dashboard-overall-top5.css
+++ b/potfill/src/main/webapp/WEB-INF/assets/css/admin/admin-dashboard-overall-top5.css
@@ -21,7 +21,7 @@
     background-color: transparent;
     color: #8094AE;
     font-weight: 600;
-    font-size: 10px !important;
+    font-size: 12px !important;
     padding: 3px 2px !important;
     text-align: center;
     border: none;
@@ -58,13 +58,16 @@
     width: 60px;
     text-align: center;
 }
+table.dataTable tbody th,table.dataTable tbody td {
+    padding: 12.5px 10px
+}
 
 .priority-table tbody td {
     padding: 2px 2px; /* 3px에서 2px로 줄임 */
     text-align: center;
     border-bottom: 1px solid #f1f3f4;
     color: #364A63;
-    font-size: 12px;
+    font-size: 14px;
     line-height: 1.1;
     height: 12px !important; 
     vertical-align: middle;

--- a/potfill/src/main/webapp/WEB-INF/assets/css/admin/admin-dashboard-overall.css
+++ b/potfill/src/main/webapp/WEB-INF/assets/css/admin/admin-dashboard-overall.css
@@ -45,7 +45,7 @@ body {
 /* ========== 핵심 지표 카드 영역 ========== */
 .metrics-section {
     width: 100%;
-    max-width: 1200px;   /* 기존 1200px → 1000px 정도로 줄이기 */
+    max-width: 83%;   /* 기존 1200px → 1000px 정도로 줄이기 */
     margin: 0 auto 10px auto;
     display: flex;
     gap: 56px;           /* 기존 38px → 20px */
@@ -81,13 +81,13 @@ body {
 }
 
 .metric-title {
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 500;
     color: #FFFCFC;
 }
 
 .metric-value {
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     font-weight: 700;
     color: #FFFCFC;
     margin-bottom: 5px;

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-rank.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-rank.js
@@ -60,7 +60,7 @@ function initRankingChart() {
                     borderRadius: 2,
                     borderSkipped: false,
                     maxBarThickness: 15,  // 막대 최대 두께 (픽셀 단위)
-                    barThickness: 10,     // 막대 고정 두께 (픽셀 단위)
+                    barThickness: 15,     // 막대 고정 두께 (픽셀 단위)
                 }]
             },
             options: {

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-rank.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-rank.js
@@ -157,8 +157,7 @@ function initRankingChart() {
         // 차트 생성
         rankingChart = new Chart(ctx, config);
         
-        console.log('지역별 우선도 랭킹 차트 초기화 완료');
-        
+  
         // 실제 데이터 로드
         fetchRankingData();
         
@@ -176,7 +175,7 @@ function fetchRankingData() {
         type: 'GET',
         dataType: 'json',
         success: function(response) {
-            console.log('지역구별 랭킹 데이터:', response);
+           /* console.log('지역구별 랭킹 데이터:', response);*/
             
             if (response && response.labels && response.data) {
                 updateRankingChartWithAPIData(response.labels, response.data);
@@ -205,8 +204,8 @@ function updateRankingChartWithAPIData(apiLabels, apiData) {
         const chartData = new Array(25).fill(0);
         
         // 디버깅용 로그
-        console.log('API 라벨:', apiLabels);
-        console.log('차트 라벨:', SEOUL_25_GU);
+     /*   console.log('API 라벨:', apiLabels);
+        console.log('차트 라벨:', SEOUL_25_GU);*/
         
         // API에서 받은 데이터를 매칭
         for (let i = 0; i < apiLabels.length; i++) {
@@ -235,8 +234,8 @@ function updateRankingChartWithAPIData(apiLabels, apiData) {
         rankingChart.data.datasets[0].data = chartData;
         rankingChart.update();
         
-        console.log('지역별 우선도 랭킹 차트 데이터 업데이트 완료');
-        console.log('최종 차트 데이터:', chartData);
+      /*  console.log('지역별 우선도 랭킹 차트 데이터 업데이트 완료');
+        console.log('최종 차트 데이터:', chartData);*/
         
     } catch (error) {
         console.error('차트 데이터 업데이트 실패:', error);

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-status.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-status.js
@@ -117,7 +117,7 @@ function initMainDonutChart() {
 			container.style.maxHeight = '170px';
 		}
 
-		console.log('메인 도넛차트 초기화 완료 (작은 크기)');
+		
 
 	} catch (error) {
 		console.error('메인 도넛차트 초기화 실패:', error);
@@ -229,7 +229,6 @@ function initMainStatusTable() {
 			}
 		});
 
-		console.log('메인 상태 테이블 초기화 완료');
 
 	} catch (error) {
 		console.error('메인 상태 테이블 초기화 실패:', error);
@@ -245,7 +244,7 @@ function loadRealData() {
 		type: 'GET',
 		dataType: 'json',
 		success: function(response) {
-			console.log('지역별 신고현황 데이터 로드:', response);
+			/*console.log('지역별 신고현황 데이터 로드:', response);*/
 			
 			// 도넛차트 데이터 업데이트
 			if (response.statusChart) {

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-status.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-status.js
@@ -222,7 +222,7 @@ function initMainStatusTable() {
 			info: false,
 			ordering: false,
 			autoWidth: false,
-			scrollY: '225px',
+			scrollY: '40.3vh',
 			scrollCollapse: true,
 			language: {
 				emptyTable: "데이터를 불러오는 중..."

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-top5.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall-top5.js
@@ -39,7 +39,7 @@ function initPriorityTable() {
         // 초기화 직후 테이블 비우기
         priorityTable.clear().draw();
 
-        console.log('우선처리 지역 TOP 5 테이블 초기화 완료');
+        /*console.log('우선처리 지역 TOP 5 테이블 초기화 완료');*/
     } catch (error) {
         console.error('우선처리 지역 TOP 5 테이블 초기화 실패:', error);
     }
@@ -71,7 +71,7 @@ function updatePriorityTableData(items) {
         });
 
         priorityTable.draw();
-        console.log('우선처리 지역 데이터 업데이트 완료:', items.length + '개 항목');
+        /*console.log('우선처리 지역 데이터 업데이트 완료:', items.length + '개 항목');*/
     } catch (error) {
         console.error('우선처리 지역 데이터 업데이트 실패:', error);
     }
@@ -81,14 +81,14 @@ function updatePriorityTableData(items) {
 function fetchPriorityData() {
     const url = contextPath + '/admin/api/dashboard/priority';
     
-    console.log('우선처리 TOP5 API 호출:', url);
+   /* console.log('우선처리 TOP5 API 호출:', url);*/
 
     $.ajax({
         url: url,
         method: 'GET',
         dataType: 'json',
         success: function (resp) {
-            console.log('우선처리 TOP5 응답:', resp);
+            /*console.log('우선처리 TOP5 응답:', resp);*/
             
             // Oracle JDBC는 컬럼명을 대문자로 반환하므로 대소문자 모두 처리
             const normalized = (Array.isArray(resp) ? resp : []).map(r => ({

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall.js
@@ -65,13 +65,13 @@ function updateTrendColors() {
         $(this).css({
             'color': '#1EE0AC',      // 민트 그린 색상
             'font-weight': '500',     // 중간 굵기
-            'font-size': '11px'       // 작은 폰트 크기
+            'font-size': '13px'       // 작은 폰트 크기
         });
     });
     
     // 전월 대비 텍스트도 작게
     $('.metric-period').css({
-        'font-size': '10px',
+        'font-size': '11px',
         'color': '#8094AE',
         'margin-top': '2px'
     });

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-dashboard-overall.js
@@ -19,7 +19,7 @@ function loadKPIData() {
         type: 'GET',
         dataType: 'json',
         success: function(data) {
-            console.log('KPI 데이터 로드 성공:', data);
+            /*console.log('KPI 데이터 로드 성공:', data);*/
             updateKPICards(data);
         },
         error: function(xhr, status, error) {

--- a/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-sidebar.js
+++ b/potfill/src/main/webapp/WEB-INF/assets/js/admin/admin-sidebar.js
@@ -1,0 +1,49 @@
+
+
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('스크립트 로드됨');
+    console.log('현재 URL:', window.location.pathname);
+    
+    // 현재 URL 경로 가져오기
+    const path = window.location.pathname;
+    
+    // 요소들이 제대로 있는지 확인
+    const navItems = document.querySelectorAll('.nav-item');
+    const subItems = document.querySelectorAll('.sub-item');
+    
+    console.log('nav-item 개수:', navItems.length);
+    console.log('sub-item 개수:', subItems.length);
+    
+    // 모든 active 클래스 제거
+    navItems.forEach(el => el.classList.remove('active'));
+    subItems.forEach(el => el.classList.remove('active'));
+    
+    // URL에 따라 메뉴 활성화
+    if (path.includes('/admin/dashboard') && !path.includes('/district')) {
+        console.log('대시보드 - 전체보기 활성화');
+        if (navItems[0]) navItems[0].classList.add('active');
+        if (subItems[0]) subItems[0].classList.add('active');
+        
+    } else if (path.includes('/district')) {
+        console.log('대시보드 - 관할보기 활성화');
+        if (navItems[0]) navItems[0].classList.add('active');
+        if (subItems[1]) subItems[1].classList.add('active');
+        
+    } else if (path.includes('/complaints')) {
+        console.log('민원관리 활성화');
+        if (navItems[1]) navItems[1].classList.add('active');
+        
+    } else if (path.includes('/map')) {
+        console.log('포트홀지도 활성화');
+        if (navItems[2]) navItems[2].classList.add('active');
+        
+    } else {
+        console.log('일치하는 URL 없음:', path);
+    }
+    
+    // 최종 상태 확인
+    setTimeout(() => {
+        console.log('활성화된 nav-item:', document.querySelectorAll('.nav-item.active').length);
+        console.log('활성화된 sub-item:', document.querySelectorAll('.sub-item.active').length);
+    }, 100);
+});

--- a/potfill/src/main/webapp/WEB-INF/views/admin/admin_component/sidebar.jsp
+++ b/potfill/src/main/webapp/WEB-INF/views/admin/admin_component/sidebar.jsp
@@ -1,50 +1,48 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
 
 <!-- 관리자 사이드바 -->
 <aside class="admin-sidebar">
-    <!-- 로고 영역 -->
-    <div class="sidebar-logo">
-        <img src="${pageContext.request.contextPath}/images/potfill-logo-white.png" 
-             alt="POTFILL 로고" class="logo">
-    </div>
-    
-    <nav class="sidebar-nav">
-        <ul class="nav-menu">
-            <!-- 대시보드 -->
-            <li class="nav-item active">
-                <a href="${pageContext.request.contextPath}/admin/dashboard" class="nav-link">
-                    <i class="nav-icon">📊</i>
-                    <span class="nav-text">대시보드</span>
-                </a>
-                <ul class="sub-menu">
-                    <li class="sub-item active">
-                        <a href="${pageContext.request.contextPath}/admin/dashboard" class="sub-link">
-                            > 전체 보기
-                        </a>
-                    </li>
-                    <li class="sub-item">
-                        <a href="${pageContext.request.contextPath}/admin/district" class="sub-link">
-                            > 관할 보기
-                        </a>
-                    </li>
-                </ul>
-            </li>
-            
-            <!-- 민원 관리 -->
-            <li class="nav-item">
-                <a href="${pageContext.request.contextPath}/admin/complaints/list" class="nav-link">
-                    <i class="nav-icon">📝</i>
-                    <span class="nav-text">민원 관리</span>
-                </a>
-            </li>
-            
-            <!-- 포트홀 지도 -->
-            <li class="nav-item">
-                <a href="${pageContext.request.contextPath}/admin/map" class="nav-link">
-                    <i class="nav-icon">🗺️</i>
-                    <span class="nav-text">포트홀 지도</span>
-                </a>
-            </li>
-        </ul>
-    </nav>
+	<!-- 로고 영역 -->
+	<div class="sidebar-logo">
+		<img
+			src="${pageContext.request.contextPath}/images/potfill-logo-white.png"
+			alt="POTFILL 로고" class="logo">
+	</div>
+
+	<nav class="sidebar-nav">
+		<ul class="nav-menu">
+			<!-- 대시보드 -->
+			<li class="nav-item"><a
+				href="${pageContext.request.contextPath}/admin/dashboard"
+				class="nav-link"> <i class="nav-icon">📊</i> <span
+					class="nav-text">대시보드</span>
+			</a>
+				<ul class="sub-menu">
+					<li class="sub-item"><a
+						href="${pageContext.request.contextPath}/admin/dashboard"
+						class="sub-link"> > 전체 보기 </a></li>
+					<li class="sub-item"><a
+						href="${pageContext.request.contextPath}/admin/district"
+						class="sub-link"> > 관할 보기 </a></li>
+				</ul></li>
+
+			<!-- 민원 관리 -->
+			<li class="nav-item"><a
+				href="${pageContext.request.contextPath}/admin/complaints/list"
+				class="nav-link"> <i class="nav-icon">📝</i> <span
+					class="nav-text">민원 관리</span>
+			</a></li>
+
+			<!-- 포트홀 지도 -->
+			<li class="nav-item"><a
+				href="${pageContext.request.contextPath}/admin/map" class="nav-link">
+					<i class="nav-icon">🗺️</i> <span class="nav-text">포트홀 지도</span>
+			</a></li>
+		</ul>
+	</nav>
 </aside>
+
+<!-- JavaScript 파일 포함 -->
+<script
+	src="${pageContext.request.contextPath}/js/admin/admin-sidebar.js"></script>

--- a/potfill/src/main/webapp/WEB-INF/views/admin/dashboard_overall/dashboard-overall.jsp
+++ b/potfill/src/main/webapp/WEB-INF/views/admin/dashboard_overall/dashboard-overall.jsp
@@ -142,7 +142,7 @@
 								<span class="section-icon">🚨</span> 우선 처리 지역 TOP 5
 								    <a href="${pageContext.request.contextPath}/admin/majorPlaceUpload" 
 								       class="btn btn-sm btn-primary me-3"
-								       style="background-color: #798BFF;border-color: #798BFF;font-size:9px;margin-left: 1%; font-size:8px">
+								       style="background-color: #798BFF;border-color: #798BFF;font-size:10px;margin-left: 1%; font-size:10px">
 								        <i class="bi bi-pin-map-fill"></i> 주요장소 업로드
 								    </a>
 							</h3>
@@ -203,7 +203,7 @@
 							</h3>
 
 							<div
-								style="text-align: center; font-size: 10px; color: #8094AE; margin-bottom: 0px;">
+								style="text-align: center; font-size: 13px; color: #8094AE; margin-bottom: 0px;">
 								전체 처리 현황</div>
 
 							<div style="display: flex; gap: 20px; margin-bottom: 0px;">
@@ -223,12 +223,12 @@
 											style="background-color: #D4DFB8; width: 18px; height: 18px; border-radius: 0px; flex-shrink: 0; margin-bottom: 15px;'"></div>
 										<div class="legend-details">
 											<div class="status-label"
-												style="font-size: 12px; color: #364A63; font-weight: 500;">완료</div>
+												style="font-size: 15px; color: #364A63; font-weight: 500;">완료</div>
 											<div class="status-value"
-												style="font-size: 13px; font-weight: 600; color: #8094AE; margin-top: 3px">
+												style="font-size: 16px; font-weight: 600; color: #8094AE; margin-top: 3px">
 												<span class="completed-count">0</span>건 <span
 													class="status-percentage"
-													style="font-size: 9px; color: #8094AE; margin-left: 3px;">0%</span>
+													style="font-size: 12px; color: #8094AE; margin-left: 3px;">0%</span>
 											</div>
 										</div>
 									</div>
@@ -239,12 +239,12 @@
 											style="background-color: #3D70C3; width: 18px; height: 18px; border-radius: 0px; flex-shrink: 0; margin-bottom: 15px;"></div>
 										<div class="legend-details">
 											<div class="status-label"
-												style="font-size: 12px; color: #364A63; font-weight: 500;">처리중</div>
+												style="font-size: 15px; color: #364A63; font-weight: 500;">처리중</div>
 											<div class="status-value"
-												style="font-size: 13px; font-weight: 600; color: #8094AE; margin-top: 3px">
+												style="font-size: 16px; font-weight: 600; color: #8094AE; margin-top: 3px">
 												<span class="processing-count">0</span>건 <span
 													class="status-percentage"
-													style="font-size: 9px; color: #8094AE; margin-left: 3px;">0%</span>
+													style="font-size: 12px; color: #8094AE; margin-left: 3px;">0%</span>
 											</div>
 										</div>
 									</div>
@@ -255,12 +255,12 @@
 											style="background-color: #FFB97D; width: 18px; height: 18px; border-radius: 0px; flex-shrink: 0; margin-bottom: 15px;"></div>
 										<div class="legend-details">
 											<div class="status-label"
-												style="font-size: 12px; color: #364A63; font-weight: 500;">접수</div>
+												style="font-size: 15px; color: #364A63; font-weight: 500;">접수</div>
 											<div class="status-value"
-												style="font-size: 13px; font-weight: 600; color: #8094AE; margin-top: 3px">
+												style="font-size: 16px; font-weight: 600; color: #8094AE; margin-top: 3px">
 												<span class="received-count">0</span>건 <span
 													class="status-percentage"
-													style="font-size: 9px; color: #8094AE; margin-left: 3px;">0%</span>
+													style="font-size: 12px; color: #8094AE; margin-left: 3px;">0%</span>
 											</div>
 										</div>
 									</div>
@@ -271,12 +271,12 @@
 											style="background-color: #868EA1; width: 18px; height: 18px; border-radius: 0px; flex-shrink: 0; margin-bottom: 15px;"></div>
 										<div class="legend-details">
 											<div class="status-label"
-												style="font-size: 12px; color: #364A63; font-weight: 500;">반려</div>
+												style="font-size: 15px; color: #364A63; font-weight: 500;">반려</div>
 											<div class="status-value"
-												style="font-size: 13px; font-weight: 600; color: #8094AE; margin-top: 3px">
+												style="font-size: 16px; font-weight: 600; color: #8094AE; margin-top: 3px">
 												<span class="rejected-count"></span>건 <span
 													class="status-percentage"
-													style="font-size: 9px; color: #8094AE; margin-left: 3px;">%</span>
+													style="font-size: 12px; color: #8094AE; margin-left: 3px;">%</span>
 											</div>
 										</div>
 									</div>
@@ -284,18 +284,18 @@
 							</div>
 
 							<div
-								style="text-align: center; font-size: 10px; color: #8094AE; margin-bottom: 5px;">
+								style="text-align: center; font-size: 13px; color: #8094AE; margin-bottom: 5px; margin-top: 5%;">
 								구별 상세 현황</div>
 
 							<div style="height: calc(100% - 180px); overflow: hidden;">
 								<table id="mainStatusTable"
-									style="width: 100%; border-collapse: collapse; font-size: 10px;">
+									style="width: 100%; border-collapse: collapse; font-size: 12px;">
 								</table>
 							</div>
 							<!-- 테이블 스타일을 위한 CSS 추가 -->
 							<style>
 #mainStatusTable tbody td {
-	font-size: 11px !important;
+	font-size: 14px !important;
 	padding: 8px 4px !important;
 	color: #364A63 !important;
 }

--- a/potfill/src/main/webapp/WEB-INF/views/admin/district/district.jsp
+++ b/potfill/src/main/webapp/WEB-INF/views/admin/district/district.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%-- <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%> --%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
# 이슈 번호
#70 

# 작업 내역
- kpi 카드 수정
- 우선 처리 지역 Top5 수정
- 지역별 우선순위 지수 수정
- 지역별 포트홀 신고현황 수정
- 사이드바 액티브 적용

---

## 1. [기능 제목 또는 간단 설명]
- 125% 배율에 맞춰있는 css를 100%에 맞게 비율 수정 및 전체 테스트와 사이드바가 액티브가 대시보드에만 고정되있는걸 모든 페이지 적용되게 수정
