### PR TITLE
fix/#77 사이즈 등급 기준 변경 및 쿼리값, 변수 등 일부 수정

### DIFF
--- a/potfill/.classpath
+++ b/potfill/.classpath
@@ -48,9 +48,6 @@
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/potfill/src/main/java/com/potfill/admin/district/model/Complaint.java
+++ b/potfill/src/main/java/com/potfill/admin/district/model/Complaint.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @Builder
 public class Complaint {
-	private int complaintId;
+	private long complaintId;
 	private String reporterName;
 	private String reporterNumber;
 	private String incidentAddress;

--- a/potfill/src/main/java/com/potfill/user/complaint/service/RiskService.java
+++ b/potfill/src/main/java/com/potfill/user/complaint/service/RiskService.java
@@ -30,7 +30,7 @@ public class RiskService {
             // 위험도 등급 계산
             int riskGrade = calculateRiskGrade(area, maxWidth);
 
-            System.out.println(complaintId + "] 위험등급 : " + riskGrade);
+            System.out.println("[ "+complaintId + " ] 위험등급 : " + riskGrade);
 
             // DB 저장 (area 없이)
             userComplaintRepository.insertRisk(complaintId, riskGrade);
@@ -59,6 +59,7 @@ public class RiskService {
         }
     }
 
+    /*
     private int calculateRiskGrade(double areaM2, double maxWidthM) {
         if (areaM2 <= 0.0 || maxWidthM <= 0.0) return 0;
 
@@ -77,5 +78,16 @@ public class RiskService {
         int grade = (int) Math.round(finalScore);
 
         return Math.max(0, Math.min(10, grade));
+    }
+    */
+    private int calculateRiskGrade(double areaM2, double maxWidthM) {
+        if (areaM2 <= 0.0) return 0;
+
+        // 면적 비례 (2㎡ → 10점, 2㎡ 이상은 10점 고정)
+        double areaScore10 = Math.min(areaM2 / 2.0, 1.0) * 10.0;
+        int grade = (int) Math.round(areaScore10);
+
+        System.out.println(">>>>> [RiskService 실행] areaM2=" + areaM2 + ", grade=" + grade);
+        return grade;
     }
 }

--- a/potfill/src/main/java/com/potfill/user/complaint/service/SizeCheckService.java
+++ b/potfill/src/main/java/com/potfill/user/complaint/service/SizeCheckService.java
@@ -75,7 +75,7 @@ public class SizeCheckService {
 		}
 	}
 
-	/** 면적 + 최대폭 기반 위험도 계산 */
+	/* 1. 면적 + 최대폭 기반 위험도 계산
 	public int calculateRiskGrade(double areaM2, double maxWidthM) {
 		if (areaM2 <= 0.0 || maxWidthM <= 0.0)
 			return 0;
@@ -113,4 +113,57 @@ public class SizeCheckService {
 
 		return Math.max(0, Math.min(10, grade));
 	}
+	*/
+	
+	/* 2. 면적 중심 가중합 
+	public int calculateRiskGrade(double areaM2, double maxWidthM) {
+	    if (areaM2 <= 0.0 || maxWidthM <= 0.0) return 0;
+
+	    // 면적 점수 (0.5㎡ 이상이면 10점)
+	    double areaScore10 = Math.min(areaM2 / 0.5, 1.0) * 10.0;
+
+	    // 폭 점수 (기존 로직 유지)
+	    double[] targets = {0.16, 0.19, 0.235, 0.295, 0.315};
+	    double sigma = 0.03, maxSim = 0.0;
+	    for (double t : targets) {
+	        double sim = Math.exp(-Math.pow(maxWidthM - t, 2) / (2 * sigma * sigma));
+	        maxSim = Math.max(maxSim, sim);
+	    }
+	    double tireScore10 = 10.0 * maxSim;
+
+	    // 가중합 (면적 70%, 폭 30%)
+	    double finalScore = 0.7 * areaScore10 + 0.3 * tireScore10;
+	    int grade = (int) Math.round(finalScore);
+
+	    System.out.println(">>>>> areaM2      : " + areaM2);
+	    System.out.println(">>>>> areaScore10 : " + areaScore10);
+	    System.out.println(">>>>> tireScore10 : " + tireScore10);
+	    System.out.println(">>>>> finalScore  : " + finalScore);
+	    System.out.println(">>>>> grade       : " + grade);
+
+	    return Math.max(0, Math.min(10, grade));
+	}
+	*/
+	
+	// 3. 면적으로만
+	/** 면적 기반 위험도 계산 (0~10, 2㎡ 기준)
+	public int calculateRiskGrade(double areaM2, double maxWidthM) {
+	    if (areaM2 <= 0.0) return 0;
+
+	    // 면적 비례 (2㎡ → 10점, 2㎡ 이상은 10점 고정)
+	    double areaScore10 = Math.min(areaM2 / 2.0, 1.0) * 10.0;
+
+	    // 정수로 반올림
+	    int grade = (int) Math.round(areaScore10);
+
+	    // 디버깅 출력
+	    System.out.println(">>>>> maxWidthM   : " + maxWidthM);
+	    System.out.println(">>>>> areaM2      : " + areaM2);
+	    System.out.println(">>>>> areaScore10 : " + areaScore10);
+	    System.out.println(">>>>> grade       : " + grade);
+
+	    return grade;
+	} */
+
+
 }

--- a/potfill/src/main/resources/mappers/admin/district/DistrictMapper.xml
+++ b/potfill/src/main/resources/mappers/admin/district/DistrictMapper.xml
@@ -39,7 +39,7 @@
                 FROM COMPLAINT_HISTORIES CH2
                 WHERE CH2.COMPLAINT_ID = C.COMPLAINT_ID
               )
-              AND CH.STATUS = '접수'
+              AND CH.STATUS = 'RECEIVED'
           )
     </select>
 
@@ -57,7 +57,7 @@
                 FROM COMPLAINT_HISTORIES CH2
                 WHERE CH2.COMPLAINT_ID = C.COMPLAINT_ID
               )
-              AND CH.STATUS = '처리중'
+              AND CH.STATUS = 'PROCESSING'
           )
     </select>
 
@@ -75,11 +75,11 @@
                 FROM COMPLAINT_HISTORIES CH2
                 WHERE CH2.COMPLAINT_ID = C.COMPLAINT_ID
               )
-              AND CH.STATUS IN ('완료', '반려')
+              AND CH.STATUS IN ('COMPLETED', 'REJECTED')
           )
     </select>
 
-    <!-- 4. 긴급 민원 리스트 (리스크 등급 5 이상) -->
+    <!-- 4. 긴급 민원 리스트 (리스크 등급 7 이상) -->
     <select id="getEmergencyList" parameterType="string" resultMap="ComplaintResultMap">
         SELECT *
         FROM (
@@ -115,7 +115,7 @@
                     WHERE ch2.COMPLAINT_ID = ch.COMPLAINT_ID
                 )
             ) lch ON c.COMPLAINT_ID = lch.COMPLAINT_ID
-            WHERE r.RISK_GRADE &gt;= 5
+            WHERE r.RISK_GRADE &gt;= 7
               AND c.GU = #{districtCode}
             ORDER BY r.RISK_GRADE DESC, c.CREATED_AT DESC
         )
@@ -144,8 +144,8 @@
         )
         SELECT
             d.CREATED_DATE AS CREATED_DATE,
-            NVL(SUM(CASE WHEN lch.STATUS = '접수' THEN 1 ELSE 0 END), 0) AS NEWCOUNT,
-            NVL(SUM(CASE WHEN lch.STATUS IN ('완료', '반려') THEN 1 ELSE 0 END), 0) AS COMPLETEDCOUNT
+            NVL(SUM(CASE WHEN lch.STATUS = 'RECEIVED' THEN 1 ELSE 0 END), 0) AS NEWCOUNT,
+            NVL(SUM(CASE WHEN lch.STATUS IN ('COMPLETED', 'REJECTED') THEN 1 ELSE 0 END), 0) AS COMPLETEDCOUNT
         FROM last7days d
         LEFT JOIN latest_complaint_histories lch
           ON TRUNC(lch.CREATED_AT) = d.CREATED_DATE

--- a/potfill/src/main/webapp/WEB-INF/views/admin/district/district.jsp
+++ b/potfill/src/main/webapp/WEB-INF/views/admin/district/district.jsp
@@ -114,12 +114,12 @@
 									<td><c:set var="isNew"
 											value="${now.time - complaint.createdAt.time <= 7*24*60*60*1000}" />
 
-										<c:if test="${isNew or complaint.status eq '접수'}">
+										<c:if test="${complaint.status eq 'Received' or complaint.status eq 'RECEIVED'}">
 											<span class="status-label status-new">신규</span>
-										</c:if> <c:if test="${complaint.status eq '처리중'}">
+										</c:if> <c:if test="${complaint.status eq 'Processing' or complaint.status eq 'PROCESSING'}">
 											<span class="status-label status-processing">처리중</span>
-										</c:if></td>
-
+										</c:if>
+									</td>
 								</tr>
 								<!-- 상세행 -->
 								<tr id="detail-${status.count}" class="collapse detail-row">
@@ -150,7 +150,7 @@
 												<input type="hidden" name="id"
 													value="${complaint.complaintId}">
 												<button type="submit" class="btn btn-primary"
-													style="background-color: #00BFFF; border: none;">접수</button>
+													style="background-color: #00BFFF; border: none;">접수상세</button>
 											</form>
 										</div></td>
 								</tr>


### PR DESCRIPTION
#77 

# 작업 내역
- 위험도 기준 변경에 따른 메서드 수정
- 쿼리 일부 수정
- 변수 일부 수정

---

## 1. [기능 제목 또는 간단 설명]
- 위험도 기준 변경에 따른 메서드 수정 : 면적에만 비례하게 수정
- 쿼리 : 상태값 대소문자 변경, 위험도 기준 7이상 데이터만 출력으로 변경
- 변수 : int 오버플로우 로 인해 long변경
